### PR TITLE
Enable creation of no-expiring subscriptions

### DIFF
--- a/client.go
+++ b/client.go
@@ -1105,11 +1105,11 @@ type connectTokenClaims struct {
 }
 
 type subscribeTokenClaims struct {
-	Client     string `json:"client"`
-	Channel    string `json:"channel"`
-	Info       Raw    `json:"info"`
-	Base64Info string `json:"b64info"`
-        SubNoExpires bool `json:"subNoExpires"`
+	Client          string `json:"client"`
+	Channel         string `json:"channel"`
+	Info            Raw    `json:"info"`
+	Base64Info      string `json:"b64info"`
+        ExpireTokenOnly bool   `json:"eto"`
 	jwt.StandardClaims
 }
 
@@ -1508,7 +1508,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, rw *replyWriter) *
 			tokenB64info = claims.Base64Info
 			tokenClient = claims.Client
 			expireAt = claims.StandardClaims.ExpiresAt
-                        if claims.SubNoExpires == true {
+                        if claims.ExpireTokenOnly == true {
                                 expireAt = 0
                         }
 

--- a/client.go
+++ b/client.go
@@ -1109,6 +1109,7 @@ type subscribeTokenClaims struct {
 	Channel    string `json:"channel"`
 	Info       Raw    `json:"info"`
 	Base64Info string `json:"b64info"`
+        SubNoExpires bool `json:"subNoExpires"`
 	jwt.StandardClaims
 }
 
@@ -1507,6 +1508,9 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, rw *replyWriter) *
 			tokenB64info = claims.Base64Info
 			tokenClient = claims.Client
 			expireAt = claims.StandardClaims.ExpiresAt
+                        if claims.SubNoExpires == true {
+                                expireAt = 0
+                        }
 
 			if c.uid != tokenClient {
 				rw.write(&protocol.Reply{Error: ErrorPermissionDenied})


### PR DESCRIPTION
Additional claim defined for subscription token: subNoExpires.
- if true - created subscription will have no expiration time, but subscription token itself expiration checks performed as usual.
- if false or omitted - default behavior